### PR TITLE
Pa/command line interface start

### DIFF
--- a/test/shift_test.rb
+++ b/test/shift_test.rb
@@ -12,6 +12,7 @@ class ShiftTest < Minitest::Test
   end
 
   def test_it_returns_date
+    @shift.stubs(:date_today => "120120")
     assert_equal "120120", @shift.date_today
   end
 
@@ -34,6 +35,7 @@ class ShiftTest < Minitest::Test
   end
 
   def test_it_returns_generated_key
+    @shift.stubs(:generated_key => "12345")
     assert_equal "12345", @shift.generated_key
   end
 

--- a/test_helper.rb
+++ b/test_helper.rb
@@ -2,5 +2,3 @@ require 'simplecov'
 SimpleCov.start
 require "minitest/autorun"
 require 'mocha/minitest'
-
-#require_relative '../test_helper'

--- a/test_helper.rb
+++ b/test_helper.rb
@@ -1,5 +1,6 @@
 require 'simplecov'
 SimpleCov.start
 require "minitest/autorun"
+require 'mocha/minitest'
 
 #require_relative '../test_helper'


### PR DESCRIPTION
Added stubs to shift test. Deployed to stub out date and key generation, these two values will change so stubbing out is necessary. 